### PR TITLE
Nashville updates production and test crontab

### DIFF
--- a/sites/nashville.production/conf/crontab_settings.txt
+++ b/sites/nashville.production/conf/crontab_settings.txt
@@ -83,13 +83,13 @@
 # SIDELOADED ECONTENT MARC triggered HERE (and commented out in full_update.sh)
 0 22 * * * cd /usr/local/vufind-plus/vufind/cron; ./sideload.sh nashville.production
 # Hoopla
-02 20 * * * cd /usr/local/vufind-plus/vufind/hoopla_export; java -jar hoopla_export.jar nashville.production
+35 19 * * * cd /usr/local/vufind-plus/vufind/hoopla_export; java -jar hoopla_export.jar nashville.production
 # Download Lexile and AR files triggered in full_update.sh
 
 ###############################
 # MNPS School Overdues Report #
 ###############################
-58 5-15 * * * cd /usr/local/vufind-plus/vufind/cron; /opt/rh/php55/root/usr/bin/php NashvilleAdHocOverdues.php nashville.production
+58 5,7,8,9,10,11,12,13,15 * * * cd /usr/local/vufind-plus/vufind/cron; /opt/rh/php55/root/usr/bin/php NashvilleAdHocOverdues.php nashville.production
 
 ###############################
 # MNPS School Barcodes Report #

--- a/sites/nashville.test/conf/crontab_settings.txt
+++ b/sites/nashville.test/conf/crontab_settings.txt
@@ -30,6 +30,7 @@
 #############
 # On Reboot #
 #############
+@reboot mkdir /var/run/mysqld; chown mysql:mysql /var/run/mysqld
 @reboot cd /usr/local/vufind-plus/sites/nashville.test/; ./nashville.test.sh start
 # Continuous Re-Indexing
 @reboot sleep 300 &&  /usr/local/VuFind-Plus/sites/nashville.test/continuous_partial_reindex.sh
@@ -84,7 +85,7 @@
 0 22 * * * cd /usr/local/vufind-plus/vufind/cron; ./sideload.sh nashville.test
 
 # Hoopla extract from API
-0 19 * * * cd /usr/local/vufind-plus/vufind/hoopla_export; java -jar hoopla_export.jar nashville.test
+30 19 * * * cd /usr/local/vufind-plus/vufind/hoopla_export; java -jar hoopla_export.jar nashville.test
 
 # Download Lexile and AR files triggered in full_update.sh
 


### PR DESCRIPTION
changes launch time for Hoopla extract
production: eliminates 2:58 and 14:58 student overdue report jobs
test: @reboot mariadb PID file hack